### PR TITLE
Add mariadb support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
   "license": "MIT",
   "type": "library",
   "description": "Export Heroku jawsdb addon configuration for WordPress.",
-  "keywords": ["Heroku", "WordPress", "JawsDB", "MySQL"],
+  "keywords": ["Heroku", "WordPress", "JawsDB", "MySQL", "MariDB"],
   "authors": [
     {
       "name": "Jussi Kinnula",
-      "email": "jussi.kinnula@frantic.com"
+      "email": "jussi.kinnula@gmail.com"
     }
   ],
   "require": {

--- a/src/JawsDB.php
+++ b/src/JawsDB.php
@@ -2,7 +2,7 @@
 
 namespace Frc\WP\Env\Heroku\JawsDB;
 
-$env = getenv('JAWSDB_URL');
+$env = getenv('JAWSDB_URL') ? getenv('JAWSDB_URL') : getenv('JAWSDB_MARIA_URL');
 if ( $env ) {
     $url = parse_url($env);
     putenv(sprintf('DB_HOST=%s', $url['host']));


### PR DESCRIPTION
This patch makes it possible to use both MySQL and MariaDB on JawsDB cloud hosted database systems.

There's only difference in exposed environment variable. By using MySQL the environment variable is `JAWSDB_URL` and by using MariaDB the environment variable is `JAWSDB_MARIA_URL`.